### PR TITLE
run+kill by process group

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -211,7 +211,7 @@ func TestPidRun(t *testing.T) {
 			}
 			testappHaproxy = d
 
-		//backend deploy app = original process, but overridden by haproxy app.pid
+		//backend deploy app = original process, but overridden by haproxy app pid
 		} else if regexp.MustCompile("node-\\d+").MatchString(d.Id) {
 			if node != nil {
 				t.Fatalf("multiple testapp node deploys running %s and %s", d.Id, node.Id)

--- a/server.go
+++ b/server.go
@@ -62,7 +62,7 @@ const (
 	serverConfigFileName = "config.json"
 	haproxyConfig        = "haproxy.cfg"
 	haproxyPid           = "haproxy.pid"
-	appPid               = "app.pid"
+	appPid               = "PID_FILE"
 )
 
 type Config struct {
@@ -296,7 +296,7 @@ func (s *ServerImpl) ListDeploys() ([]*Deploy, error) {
 		proc, running := procsByDeployId[deployId]
 		if pidOverride, err := s.getDeployPidOverride(deployId); err == nil {
 			if _, ok := procsByPid[pidOverride]; ok {
-				//found a process matching the app.pid override
+				//found a process matching the app pid override
 				proc, running = procsByPid[pidOverride]
 			}
 		}

--- a/testapp/app.js
+++ b/testapp/app.js
@@ -60,5 +60,6 @@ function startProxy(frontPort, appPort) {
     if (err instanceof Error) {
       throw err;
     }
+    process.exit(code);
   });
 }

--- a/testapp/start-haproxy.sh
+++ b/testapp/start-haproxy.sh
@@ -12,9 +12,9 @@ cat haproxy.cfg.tpl | sed "s|%FRONTPORT%|$FRONT|g" | sed "s|%APPPORT%|$APP|g" > 
 
 
 function finish {
-  echo "cleaning up app.pid $PID"
+  echo "cleaning up app pid $PID"
   kill $PID
-  rm -f app.pid
+  rm -f PID_FILE
 }
 
 trap finish EXIT
@@ -25,6 +25,6 @@ exec haproxy -f "$TEMP" &
 PID=$!
 echo "exec'd $PID"
 cd -
-echo "$PID" > app.pid
+echo "$PID" > PID_FILE
 echo "wait for $PID"
 wait $PID


### PR DESCRIPTION
go proc.Kill doesn't seem to kill children
(see also here: http://stackoverflow.com/a/29552044)
so stop() can be a bit flaky if shutdown hooks don't work
rutting the command with an (automatically) assigned process group and killing it this way seems to be more reliable