### PR TITLE
Modifying how data is written in to test app

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -374,8 +374,8 @@ func TestStop(t *testing.T) {
 	}
 }
 
-func atomicWriteFile(t *testing.T, data string, filename string) error {
-  tempFile, err := ioutil.TempFile(os.TempDir(), "tempData")
+func atomicWriteFile(data string, filename string) error {
+	tempFile, err := ioutil.TempFile(os.TempDir(), "tempData")
 	if err != nil {
 		return fmt.Errorf("could not create temp file: %s\n", err)
 	}
@@ -385,22 +385,22 @@ func atomicWriteFile(t *testing.T, data string, filename string) error {
 
 	_, err = tempFile.Write([]byte(data))
 	if err != nil {
-		fmt.Errorf("Could not write to temp file: %s\n", err)
+		return fmt.Errorf("Could not write to temp file: %s\n", err)
 	}
 
 	err = os.Rename(tempFile.Name(), filename)
 	if err != nil {
-		fmt.Errorf("Could not move temp file to testapp: %s\n", err)
+		return fmt.Errorf("Could not move temp file to testapp: %s\n", err)
 	}
 
-  return nil
+	return nil
 }
 
 func writeDataIntoTestapp(t *testing.T, data string) {
-	err := atomicWriteFile(t, data, "testapp/data/file")
-  if (err != nil) {
-    t.Fatalf("%s", err)
-  }
+	err := atomicWriteFile(data, "testapp/data/file")
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
 }
 
 func expectGet(t *testing.T, port int, path, expected string) {

--- a/integration_test.go
+++ b/integration_test.go
@@ -375,10 +375,24 @@ func TestStop(t *testing.T) {
 }
 
 func writeDataIntoTestapp(t *testing.T, data string) {
-	err := ioutil.WriteFile("testapp/data/file", []byte(data), os.FileMode(0644))
+	tempFile, err := ioutil.TempFile(os.TempDir(), "tempData")
 	if err != nil {
-		t.Fatalf("write file: %s\n", err)
+		t.Fatalf("could not create temp file: %s\n", err)
 	}
+
+	_, err = tempFile.Write([]byte(data))
+	if err != nil {
+		os.Remove(tempFile.Name())
+		t.Fatalf("Could not write to temp file: %s\n", err)
+	}
+
+	tempFile.Close()
+	err = os.Rename(tempFile.Name(), "testapp/data/file")
+	if err != nil {
+		os.Remove(tempFile.Name())
+		t.Fatalf("Could not move temp file to testapp: %s\n", err)
+	}
+
 }
 
 func expectGet(t *testing.T, port int, path, expected string) {

--- a/integration_test.go
+++ b/integration_test.go
@@ -374,10 +374,10 @@ func TestStop(t *testing.T) {
 	}
 }
 
-func writeDataIntoTestapp(t *testing.T, data string) {
-	tempFile, err := ioutil.TempFile(os.TempDir(), "tempData")
+func atomicWriteFile(t *testing.T, data string, filename string) error {
+  tempFile, err := ioutil.TempFile(os.TempDir(), "tempData")
 	if err != nil {
-		t.Fatalf("could not create temp file: %s\n", err)
+		return fmt.Errorf("could not create temp file: %s\n", err)
 	}
 
 	defer os.Remove(tempFile.Name())
@@ -385,14 +385,22 @@ func writeDataIntoTestapp(t *testing.T, data string) {
 
 	_, err = tempFile.Write([]byte(data))
 	if err != nil {
-		t.Fatalf("Could not write to temp file: %s\n", err)
+		fmt.Errorf("Could not write to temp file: %s\n", err)
 	}
 
-	err = os.Rename(tempFile.Name(), "testapp/data/file")
+	err = os.Rename(tempFile.Name(), filename)
 	if err != nil {
-		t.Fatalf("Could not move temp file to testapp: %s\n", err)
+		fmt.Errorf("Could not move temp file to testapp: %s\n", err)
 	}
 
+  return nil
+}
+
+func writeDataIntoTestapp(t *testing.T, data string) {
+	err := atomicWriteFile(t, data, "testapp/data/file")
+  if (err != nil) {
+    t.Fatalf("%s", err)
+  }
 }
 
 func expectGet(t *testing.T, port int, path, expected string) {

--- a/integration_test.go
+++ b/integration_test.go
@@ -380,16 +380,16 @@ func writeDataIntoTestapp(t *testing.T, data string) {
 		t.Fatalf("could not create temp file: %s\n", err)
 	}
 
+	defer os.Remove(tempFile.Name())
+	defer tempFile.Close()
+
 	_, err = tempFile.Write([]byte(data))
 	if err != nil {
-		os.Remove(tempFile.Name())
 		t.Fatalf("Could not write to temp file: %s\n", err)
 	}
 
-	tempFile.Close()
 	err = os.Rename(tempFile.Name(), "testapp/data/file")
 	if err != nil {
-		os.Remove(tempFile.Name())
 		t.Fatalf("Could not move temp file to testapp: %s\n", err)
 	}
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -397,8 +397,7 @@ func atomicWriteFile(data string, filename string) error {
 }
 
 func writeDataIntoTestapp(t *testing.T, data string) {
-	err := atomicWriteFile(data, "testapp/data/file")
-	if err != nil {
+	if err := atomicWriteFile(data, "testapp/data/file"); err != nil {
 		t.Fatalf("%s", err)
 	}
 }


### PR DESCRIPTION
I was having some issues running the integration tests, in particular with TestHaproxy where data is written in to the testapp. What I was seeing was that the second time data was written in to the test app the write would not complete before the test app was deployed. 

I've changed the method for writing this data file to utilise a different method of writing to this file to make sure that it's been completed before deployment by utilising the fact that os.Rename is atomic. 