### PR TITLE
Report on the currently active deploy

### DIFF
--- a/haproxy.go
+++ b/haproxy.go
@@ -25,7 +25,7 @@ const (
 	// needs to be consistent from when the server is first
 	// started, as it is used to define the currently active
 	// deploy
-	backendProcessName = "thing-"
+	backendProcessName = "deployed-app-"
 )
 
 var cfgTemplate = `
@@ -134,7 +134,7 @@ func parseBackendEntry(row []string) (bool, int) {
 	pxName := row[haProxyPxnameIndex]
 	if strings.Contains(pxName, backendProcessName) {
 		// Get the port number
-		portStr := strings.Split(pxName, "-")[1]
+		portStr := strings.TrimPrefix(pxName, backendProcessName)
 		port, err := strconv.Atoi(portStr)
 
 		if err != nil {

--- a/haproxy.go
+++ b/haproxy.go
@@ -1,8 +1,31 @@
 package main
 
 import (
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
 	"strconv"
 	"strings"
+)
+
+const (
+	// This is the index of the process name for each of the
+	// processes currently being tracked by HaProxy
+	haProxyPxnameIndex = 0
+	// This is the index of the status of each process
+	// currently being tracked by HaProxy
+	haProxyStatusIndex = 17
+	// This is the status page that can be read when HaProxy is
+	// running
+	haProxyStatusPage = "http://localhost:%d/;csv"
+	// This is a name given to the app being deployed when setting
+	// it up in HaProxy. The name can be anything, it just
+	// needs to be consistent from when the server is first
+	// started, as it is used to define the currently active
+	// deploy
+	backendProcessName = "thing-"
 )
 
 var cfgTemplate = `
@@ -42,10 +65,10 @@ listen stats
 
 frontend main
     bind *:%FRONT_PORT%
-    default_backend thing-%APP_PORT%
+    default_backend %BACKEND_ENTRY%
 
 
-backend thing-%APP_PORT%
+backend %BACKEND_ENTRY%
     balance leastconn
 
     server app-server-%APP_PORT% 127.0.0.1:%APP_PORT% check inter 2000
@@ -57,12 +80,83 @@ func HaproxyConfig(statsPort int, frontPort int, appPort int) string {
 	str = replace(str, "STATS_PORT", statsPort)
 	str = replace(str, "FRONT_PORT", frontPort)
 	str = replace(str, "APP_PORT", appPort)
+	str = strings.Replace(str, "%BACKEND_ENTRY%", nameBackendEntry(appPort), -1)
 
 	return str
 }
 
 func replace(str string, varname string, num int) string {
 	return strings.Replace(str, "%"+varname+"%", strconv.Itoa(num), -1)
+}
+
+// This looks through the HaProxy status page to determine
+// which port is currently being pointed to by HaProxy.
+// The haProxyPort is the port on which the status page
+// can be accessed. Normally this is the end port for the
+// server implementation.
+func getPortMarkedAsSet(haProxyPort int) (int, error) {
+
+	url := fmt.Sprintf(haProxyStatusPage, haProxyPort)
+	resp, err := http.Get(url)
+	if err != nil {
+		// Couldn't connect to haproxy don't modify the deploy list
+		return -1, fmt.Errorf("Could not connect to status page, got error: %s", err)
+	}
+
+	defer resp.Body.Close()
+
+	records, err := csv.NewReader(resp.Body).ReadAll()
+	if err != nil {
+		return -1, err
+	}
+
+	for i, row := range records {
+
+		// skip header
+		if i == 0 {
+			continue
+		}
+
+		// Find the first row that contains a Process name that
+		// matches the app id.
+		ok, port := parseBackendEntry(row)
+		if ok {
+			return port, nil
+		}
+
+	}
+
+	return -1, errors.New(fmt.Sprintf("haProxy has does not have an application marked as set\n"))
+
+}
+
+func parseBackendEntry(row []string) (bool, int) {
+	pxName := row[haProxyPxnameIndex]
+	if strings.Contains(pxName, backendProcessName) {
+		// Get the port number
+		portStr := strings.Split(pxName, "-")[1]
+		port, err := strconv.Atoi(portStr)
+
+		if err != nil {
+			log.Println("Could not parse port: ", portStr, " as int")
+			return false, 0
+		}
+
+		// Check if that process is UP
+		status := row[haProxyStatusIndex]
+		if strings.Compare(status, "UP") == 0 {
+			return true, port
+		} else {
+			log.Println("App on active port: ", port, " is down")
+			return false, 0
+		}
+
+	}
+	return false, 0
+}
+
+func nameBackendEntry(port int) string {
+	return fmt.Sprintf("%s%d", backendProcessName, port)
 }
 
 // /usr/local/sbin/haproxy -f /etc/haproxy/haproxy.cfg -p /var/run/haproxy.pid -sf $(cat /var/run/haproxy.pid )

--- a/integration_test.go
+++ b/integration_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"errors"
 )
 
 type testClient struct {
@@ -549,4 +550,66 @@ func TestPort(t *testing.T) {
 	if deploys[0].Health != 0 {
 		t.Fatalf("expected health to be 0, but is %d", deploys[0].Health)
 	}
+}
+
+// This will return the active deploy from the given list
+// or nil if there is no active deploy. This will return an
+// error if more than one deploy is marked as active
+func getActiveDeploy(deploys []*Deploy) (*Deploy, error) {
+	var activeDeploy *Deploy
+	activeDeploy = nil
+	for _, deploy := range deploys {
+		if deploy.Set {
+			// Check that there isn't already an active deploy
+			if activeDeploy != nil {
+				return nil, errors.New("More than one deploy marked as active")
+			}
+			activeDeploy = deploy
+		}
+	}
+	return activeDeploy, nil
+}
+
+func expectActiveDeploy(t *testing.T, deploys []*Deploy, deployId string) {
+	activeDeploy, err := getActiveDeploy(deploys)
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+
+	if activeDeploy == nil && deployId != "" {
+		t.Fatalf("No deploy is marked as active, expected %s", deployId)
+	} else if activeDeploy != nil && activeDeploy.Id != deployId {
+		t.Fatalf("Expected %s to be marked as active, got %s", deployId, activeDeploy.Id)
+	}
+}
+
+// TestActivePort tests whether deploys are marked as active correctly
+func TestActiveDeploy(t *testing.T) {
+	client, server := startCamus(t)
+	defer server.Kill()
+	defer client.Shutdown()
+
+	client.Build()
+	v1DeployId := client.Push()
+	v2DeployId := client.Push()
+
+	client.Run(v1DeployId)
+	client.Run(v2DeployId)
+
+	// No deploys should be marked as active
+	expectActiveDeploy(t, client.ListDeploys(), "")
+	
+	client.SetActiveById(v1DeployId)
+	// Expect v1 to be active
+	expectActiveDeploy(t, client.ListDeploys(), v1DeployId)
+
+	client.SetActiveById(v2DeployId)
+	// Expect v2 to be active
+	expectActiveDeploy(t, client.ListDeploys(), v2DeployId)
+
+
+	// Stop the currently active client, check that no deploys are active
+	client.Stop(v2DeployId)
+	expectActiveDeploy(t, client.ListDeploys(), "")
+
 }

--- a/terminal_client.go
+++ b/terminal_client.go
@@ -119,7 +119,7 @@ func (c *TerminalClient) listCmd() error {
 
 	tbl := TableDef{
 		Columns: []ColumnDef{
-			ColumnDef{"id", 25},
+			ColumnDef{"id", 42},
 			ColumnDef{"pid", 5},
 			ColumnDef{"tracked", 7},
 			ColumnDef{"port", 4},
@@ -136,7 +136,7 @@ func (c *TerminalClient) listCmd() error {
 			yn(deploy.Tracked),
 			deploy.Port,
 			deploy.Health,
-			fmt.Sprintf("%v", deploy.Errors),
+			fmt.Sprintf("%v %s", deploy.Errors, activePointer(deploy.Set)),
 		)
 	}
 	return nil
@@ -172,3 +172,12 @@ func yn(b bool) string {
 		return "n"
 	}
 }
+
+func activePointer(b bool) string {
+  if b {
+    return "<--- ACTIVE"
+  } else {
+    return ""
+  }
+}
+

--- a/terminal_client.go
+++ b/terminal_client.go
@@ -119,7 +119,7 @@ func (c *TerminalClient) listCmd() error {
 
 	tbl := TableDef{
 		Columns: []ColumnDef{
-			ColumnDef{"id", 42},
+			ColumnDef{"   id", 45},
 			ColumnDef{"pid", 5},
 			ColumnDef{"tracked", 7},
 			ColumnDef{"port", 4},
@@ -131,12 +131,12 @@ func (c *TerminalClient) listCmd() error {
 
 	for _, deploy := range deploys {
 		tbl.PrintRow(
-			deploy.Id,
+			fmt.Sprintf("%s%s", activePointer(deploy.Set), deploy.Id),
 			deploy.Pid,
 			yn(deploy.Tracked),
 			deploy.Port,
 			deploy.Health,
-			fmt.Sprintf("%v %s", deploy.Errors, activePointer(deploy.Set)),
+			fmt.Sprintf("%v", deploy.Errors),
 		)
 	}
 	return nil
@@ -174,10 +174,9 @@ func yn(b bool) string {
 }
 
 func activePointer(b bool) string {
-  if b {
-    return "<--- ACTIVE"
-  } else {
-    return ""
-  }
+	if b {
+		return " * "
+	} else {
+		return "   "
+	}
 }
-


### PR DESCRIPTION
Using the haproxy status page as the source of truth regarding which deploy is active.

- Added the Set flag to the deploy struct. 
- Added a pointer to the active deploy when list deploys is called. 
- Added a unit test to make sure the active port is being reported correctly
- Changed the width of the deploy ID column as it was not wide enough to accomodate the city names and adjectives (it should now accomodate the longest possible combination)