### PR TITLE
Allow terminal commands to use ID prefix

### DIFF
--- a/rpc_server.go
+++ b/rpc_server.go
@@ -55,7 +55,12 @@ type RunReply struct {
 }
 
 func (s *RpcServer) Run(arg RunRequest, reply *RunReply) error {
-	port, err := s.server.Run(arg.DeployId)
+	deployId, err := s.server.GetFullDeployIdFromShortName(arg.DeployId)
+	if err != nil {
+		return err
+	}
+
+	port, err := s.server.Run(deployId)
 	if err != nil {
 		return err
 	}
@@ -101,7 +106,12 @@ type StopDeployResponse struct {
 }
 
 func (s *RpcServer) StopDeploy(arg StopDeployRequest, reply *StopDeployResponse) error {
-	return s.server.Stop(arg.DeployId)
+	deployId, err := s.server.GetFullDeployIdFromShortName(arg.DeployId)
+	if err != nil {
+		return err
+	}
+
+	return s.server.Stop(deployId)
 }
 
 ////////////////

--- a/server.go
+++ b/server.go
@@ -420,6 +420,23 @@ func (s *ServerImpl) SetActiveById(id string) error {
 	return fmt.Errorf("No deploy %s, run 'list' to see valid deploys", id)
 }
 
+func (s *ServerImpl) GetFullDeployIdFromShortName(deployShortName string) (string, error) {
+  var matchingIds []string
+  for _, deployId := range s.readDeployIdsFromDisk() {
+    shortenedId := strings.TrimPrefix(deployId, deployShortName)
+    if shortenedId != deployId {
+      matchingIds = append(matchingIds, deployId)
+    }
+  }
+
+  numMatching := len(matchingIds)
+  if numMatching != 1 {
+    return "",fmt.Errorf("short name corresponds to %d deploy IDs, be more specific", numMatching)
+  }
+
+  return matchingIds[0], nil
+}
+
 func (s *ServerImpl) Run(deployIdToRun string) (int, error) {
 	for port, deployId := range s.config.Ports {
 		if deployIdToRun == deployId {

--- a/server.go
+++ b/server.go
@@ -63,6 +63,7 @@ const (
 	haproxyConfig        = "haproxy.cfg"
 	haproxyPid           = "haproxy.pid"
 	appPid               = "PID_FILE"
+	minShortNameLength   = 3
 )
 
 type Config struct {
@@ -421,20 +422,23 @@ func (s *ServerImpl) SetActiveById(id string) error {
 }
 
 func (s *ServerImpl) GetFullDeployIdFromShortName(deployShortName string) (string, error) {
-  var matchingIds []string
-  for _, deployId := range s.readDeployIdsFromDisk() {
-    shortenedId := strings.TrimPrefix(deployId, deployShortName)
-    if shortenedId != deployId {
-      matchingIds = append(matchingIds, deployId)
-    }
-  }
+	if len(deployShortName) < minShortNameLength {
+		return "", fmt.Errorf("Deploy name substring is too short, needs to be at least %d characters", minShortNameLength)
+	}
 
-  numMatching := len(matchingIds)
-  if numMatching != 1 {
-    return "",fmt.Errorf("short name corresponds to %d deploy IDs, be more specific", numMatching)
-  }
+	var matchingIds []string
+	for _, deployId := range s.readDeployIdsFromDisk() {
+		if strings.Contains(deployId, deployShortName) {
+			matchingIds = append(matchingIds, deployId)
+		}
+	}
 
-  return matchingIds[0], nil
+	numMatching := len(matchingIds)
+	if numMatching != 1 {
+		return "", fmt.Errorf("short name corresponds to %d deploy IDs, be more specific", numMatching)
+	}
+
+	return matchingIds[0], nil
 }
 
 func (s *ServerImpl) Run(deployIdToRun string) (int, error) {


### PR DESCRIPTION
This change is to allow camus terminal client commands that require a deploy ID (Run, Stop) to only use a prefix of the ID. Any length prefix can be used, as long as it's unique .

The method which matches up an deploy ID prefix to a full deploy ID can be found in server.go. There are several places this method could be called, but I wanted to put it in a place that had the least impact to existing code. This is why I called the method in the RPC server methods, Run and Stop, by converting the short name in to the full ID there, everything else stays the same. 